### PR TITLE
Fix maintainer field

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,7 +1,6 @@
 name: munge
 summary: A layer responsible for munge key handling
-maintainer:
-  - Dmitrii Shcherbakov <dmitrii.shcherbakov@canonical.com>
+maintainer: Dmitrii Shcherbakov <dmitrii.shcherbakov@canonical.com>
 description: |
   A layer for using a pre-configured munge key, generating munge key
   if not provided or handling one provided via a relation. Also used


### PR DESCRIPTION
This field was originally committed as a list instead of being a string
which caused this to happen during charm build:

https://github.com/omnivector-solutions/layer-slurm-controller/issues/4